### PR TITLE
[codex] Stabilize main deploy workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,13 @@ jobs:
         run: |
           set -euxo pipefail
           mkdir -p /tmp/godot "$HOME/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_STATUS}"
-          curl -L -o /tmp/godot/godot.zip "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-${GODOT_STATUS}/Godot_v${GODOT_VERSION}-${GODOT_STATUS}_linux.x86_64.zip"
+          curl --fail --location --show-error --retry 3 --retry-delay 2 --retry-all-errors -o /tmp/godot/godot.zip "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-${GODOT_STATUS}/Godot_v${GODOT_VERSION}-${GODOT_STATUS}_linux.x86_64.zip"
+          unzip -t /tmp/godot/godot.zip
           unzip -q /tmp/godot/godot.zip -d /tmp/godot
           chmod +x "/tmp/godot/Godot_v${GODOT_VERSION}-${GODOT_STATUS}_linux.x86_64"
           sudo ln -sf "/tmp/godot/Godot_v${GODOT_VERSION}-${GODOT_STATUS}_linux.x86_64" /usr/local/bin/godot
-          curl -L -o /tmp/godot/export_templates.tpz "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-${GODOT_STATUS}/Godot_v${GODOT_VERSION}-${GODOT_STATUS}_export_templates.tpz"
+          curl --fail --location --show-error --retry 3 --retry-delay 2 --retry-all-errors -o /tmp/godot/export_templates.tpz "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-${GODOT_STATUS}/Godot_v${GODOT_VERSION}-${GODOT_STATUS}_export_templates.tpz"
+          unzip -t /tmp/godot/export_templates.tpz
           unzip -q /tmp/godot/export_templates.tpz -d /tmp/godot/export_templates
           cp -R /tmp/godot/export_templates/templates/. "$HOME/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_STATUS}/"
 
@@ -62,6 +64,13 @@ jobs:
 
       - name: Run unit tests
         run: npm run test
+
+      - name: Upload Godot Web export
+        uses: actions/upload-artifact@v4
+        with:
+          name: godot-web-dist
+          path: dist
+          if-no-files-found: error
 
   deploy:
     needs: test
@@ -77,34 +86,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
+      - name: Download Godot Web export
+        uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0
-
-      - name: Setup Node.js 22.x
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22.x
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Godot export tooling
-        run: |
-          set -euxo pipefail
-          mkdir -p /tmp/godot "$HOME/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_STATUS}"
-          curl -L -o /tmp/godot/godot.zip "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-${GODOT_STATUS}/Godot_v${GODOT_VERSION}-${GODOT_STATUS}_linux.x86_64.zip"
-          unzip -q /tmp/godot/godot.zip -d /tmp/godot
-          chmod +x "/tmp/godot/Godot_v${GODOT_VERSION}-${GODOT_STATUS}_linux.x86_64"
-          sudo ln -sf "/tmp/godot/Godot_v${GODOT_VERSION}-${GODOT_STATUS}_linux.x86_64" /usr/local/bin/godot
-          curl -L -o /tmp/godot/export_templates.tpz "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-${GODOT_STATUS}/Godot_v${GODOT_VERSION}-${GODOT_STATUS}_export_templates.tpz"
-          unzip -q /tmp/godot/export_templates.tpz -d /tmp/godot/export_templates
-          cp -R /tmp/godot/export_templates/templates/. "$HOME/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_STATUS}/"
-
-      - name: Build project
-        run: npm run build:public
+          name: godot-web-dist
+          path: dist
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/test/godot-v2-export.test.ts
+++ b/test/godot-v2-export.test.ts
@@ -100,9 +100,25 @@ describe('Godot v2 export workflow', () => {
     expect(workflow).toContain('GODOT_STATUS: stable');
     expect(workflow).toContain('Godot_v${GODOT_VERSION}-${GODOT_STATUS}_linux.x86_64.zip');
     expect(workflow).toContain('Godot_v${GODOT_VERSION}-${GODOT_STATUS}_export_templates.tpz');
+    expect(workflow.match(/curl --fail --location --show-error --retry 3 --retry-delay 2 --retry-all-errors/g)).toHaveLength(2);
+    expect(workflow).toContain('unzip -t /tmp/godot/godot.zip');
+    expect(workflow).toContain('unzip -t /tmp/godot/export_templates.tpz');
     expect(workflow).toContain('npm run build:public');
     expect(workflow).toContain('path: dist');
     expect(workflow).not.toContain('build:legacy:web');
+  });
+
+  it('deploys the Godot Web export artifact built by the test job', () => {
+    const workflow = readText('.github/workflows/test.yml');
+    const installStepCount = workflow.match(/name: Install Godot export tooling/g)?.length ?? 0;
+    const buildPublicCount = workflow.match(/npm run build:public/g)?.length ?? 0;
+
+    expect(workflow).toContain('uses: actions/upload-artifact@v4');
+    expect(workflow).toContain('uses: actions/download-artifact@v4');
+    expect(workflow).toContain('name: godot-web-dist');
+    expect(workflow).toContain('if-no-files-found: error');
+    expect(installStepCount).toBe(1);
+    expect(buildPublicCount).toBe(1);
   });
 
   it('documents the default Godot Web build command and removes Phaser deployment guidance', () => {


### PR DESCRIPTION
## Summary
- Reuse the Godot Web export built in the test job for Pages deploys instead of rebuilding in the deploy job.
- Upload `dist` as a workflow artifact and download it in the deploy job before `upload-pages-artifact`.
- Harden the remaining Godot/tooling downloads with `curl --fail`, retries, and zip validation.

## Root cause
The failing main run completed the test job successfully, then failed in the deploy job while downloading Godot again. The downloaded `godot.zip` was only 55 KB and was not a zip file, so `unzip` failed. Reusing the already-built `dist` artifact removes that second external Godot download from deploy.

## Validation
- Red: `npx vitest run test/godot-v2-export.test.ts` failed before the workflow change on the new artifact contract.
- Green: `npx vitest run test/godot-v2-export.test.ts`
- Green: `npm run test`